### PR TITLE
fix-precision

### DIFF
--- a/src/calculatorgui_impl.cpp
+++ b/src/calculatorgui_impl.cpp
@@ -725,12 +725,13 @@ wxString Dlg::Report_Value(double in_Value, int in_mode){
         case 1:
             //printf("Precise, thousands separator\n");
             //setlocale(LC_ALL,""); //Causes Serious errors in OPENCPN, rounding all tracks waypoints and incoming data.
-//SaltyPaws version	works for win		
+//SaltyPaws version	works for win
+/*		
          return ThousandSeparator(wxString::Format(wxT("%'.15g"), in_Value));
+*/		 
 //Rasbats version
-/*
+
 	        return ThousandSeparator(wxString::Format(wxT("%.15g"), in_Value));		
-*/
             //return Temp_String;
             break;
 


### PR DESCRIPTION
This should fix the precision problem. It basically uses your line instead of SaltyPaws line.
I've tested it for precision (thousands) and succinct (thousands).
I don't understand why it fixes the succinct (thousands) but it seems to work.

Well, first you have to un-revert my pull request #2 Reintroduce Saltypaws changes that work, then apply this PR.